### PR TITLE
TwocheckoutError is actually twocheckout.TwocheckoutError in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ params = {
 try:
     result = twocheckout.Charge.authorize(params)
     print result.responseCode
-except TwocheckoutError as error:
+except twocheckout.TwocheckoutError as error:
     print error.msg
 
 ```


### PR DESCRIPTION
This is a simple typo can be confusing for some.